### PR TITLE
fix: use loop index for debug printing

### DIFF
--- a/robinhoodhash.h
+++ b/robinhoodhash.h
@@ -69,7 +69,7 @@
         if (tbl##_isnil(u, _rh_i)) { \
             printf("___+__ "); \
         } else { \
-            printf("%03u+%02d ", tbl##_getkey(u,_rh_i), tbl##_getbucket(u,tbl##_getkey(u,i))); \
+            printf("%03u+%02d ", tbl##_getkey(u,_rh_i), tbl##_getbucket(u,tbl##_getkey(u,_rh_i))); \
         } \
     } \
     printf("\n"); \


### PR DESCRIPTION
Previously, the internal debug printing used an undeclared variable.

This updates to use the internal `_rh_i` index.